### PR TITLE
Add finalized agenda and abstracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 This is the website landing page for the RSE-eScience-2022 workshop to be
 held in conjunction with [eScience 2022](https://www.escience-conference.org/2022/)
-in Salt Lake City, Utah, October 11-14, 2022.
+in Salt Lake City, Utah, October 10-14, 2022.
 
 The deployed site is TBD.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 This is the website landing page for the RSE-eScience-2022 workshop to be
 held in conjunction with [eScience 2022](https://www.escience-conference.org/2022/)
-in Salt Lake City, Utah, October 10-14, 2022.
+in Salt Lake City, Utah.
 
 The deployed site is TBD.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ fb-img:
 <div class="main-explain-area jumbotron">
   <h2><center>To be held as part of
   <a href='https://www.escience-conference.org/2022/'>eScience 2022</a>,
-  Salt Lake City, Utah, October 10-14, 2022.
+  Salt Lake City, Utah.
   </center></h2>
 
   <p>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ fb-img:
 <div class="main-explain-area jumbotron">
   <h2><center>To be held as part of
   <a href='https://www.escience-conference.org/2022/'>eScience 2022</a>,
-  Salt Lake City, Utah, October 11-14, 2022.
+  Salt Lake City, Utah, October 10-14, 2022.
   </center></h2>
 
   <p>
@@ -38,10 +38,10 @@ fb-img:
     <li>Submissions open:  Monday, April 11, 2022</li>
     <li><strike>Full paper submissions due (to be included with official proceedings):  Tuesday, May 31, 2022</strike></li>
     <li><strike>Notifications sent:  Monday, June 27, 2022</strike></li>
-    <li>Abstract/short paper submissions due (will <b>NOT</b> be included with official proceedings): Monday, July 18, 2022 - <b>EXTENDED</b></li>
-    <li>Notifications sent:  Monday, August 1, 2022 - <b>EXTENDED</b></li>
-    <li>Program finalized:  Monday, August 15, 2022</li>
-    <li>Workshop date:  TBD</li>
+    <li><strike>Abstract/short paper submissions due (will <b>NOT</b> be included with official proceedings): Monday, July 18, 2022 - <b>EXTENDED</b></strike></li>
+    <li><strike>Notifications sent:  Monday, August 1, 2022 - <b>EXTENDED</b></strike></li>
+    <li>Program finalized:  Wednesday, August 17, 2022</li>
+    <li>Workshop date:  Tuesday, October 11, 1:30-4:30PM (MDT)</li>
   </ul>
 
   <p>

--- a/pages/abstracts.md
+++ b/pages/abstracts.md
@@ -1,0 +1,134 @@
+---
+layout: page
+title: Workshop Abstracts
+description: Workshop Abstracts
+permalink: /abstracts/
+---
+
+## Talks
+
+### Benefits and Limitations of Jupyter-based Scientific Web Applications
+
+*Nicole Brewer, Rob Campbell, Rajesh Kalyanam, I Luk Kim, and Carol X. Song*
+
+Scientists are increasingly interested in creating standalone web-applications
+as computational and data analysis tools. The authors have worked with several
+such research groups to design, develop, and deploy such web applications that
+are increasingly based on Jupyter notebooks. One of the primary reasons among
+many to use Jupyter notebooks is the fact that research groups inheriting these
+pplications are capable of maintaining and extending them. In this paper, we
+walk through the design process for one such application and discuss 
+development environments that are best suited to Jupyter notebook development.
+We then explore several other applications where we employ similar design
+patterns. In doing so, we expound upon the benefits, limitations, and
+challenges of Notebook-based applications to provide a guide for other
+facilitators in similar situations
+
+---
+
+### Roles of Professional Research Software Engineers in the Science Gateway Landscape
+
+*Sandra Gesing*
+
+Science gateways are increasingly used by researchers and educators evident
+in publications and presentations at events such as eScience and PEARC. Teams
+around science gateway development are diverse and need a diverse set of
+expertise. Skills needed are around developing and/or extending a science
+gateway framework with backend connections to complex research infrastructure
+or lab instruments, enabling collaboration with authentication and
+authorization mechanism as well as addressing FAIR (Findable, Accessible,
+Interoperable, Reusable) principles. One of the most important aspects are the
+needs of the specific community for each science gateway on features and
+user interface. 
+
+---
+
+### Half-Precision Scalar Support in Kokkos and Kokkos Kernels: An Engineering Study and Experience Report
+
+*Evan Harvey, Reed Milewicz, Christian Trott, Luc Berger-Vergiat, and Siva Rajamanickam*
+
+To keep pace with the demand for innovation through scientific computing,
+modern scientific software development is increasingly reliant upon a rich
+and diverse ecosystem of software libraries and toolchains. Research software
+engineers (RSEs) responsible for that infrastructure perform highly 
+integrative work, acting as a bridge between the hardware, the needs of
+researchers, and the software layers situated between them; relatively little,
+however, has been written about the role played by RSEs in that work and what
+support they need to thrive.
+
+To that end, we present a two-part report on the development of half-precision
+floating point support in the Kokkos Ecosystem. Half-precision computation is
+a promising strategy for increasing performance in numerical computing and
+is particularly attractive for emerging application areas (e.g., machine
+learning), but developing practicable, portable, and user-friendly abstractions
+is a nontrivial task. In the first half of the paper, we conduct an engineering
+study on the technical implementation of the Kokkos half-precision scalar
+feature and showcase experimental results; in the second half, we offer an
+experience report on the challenges and lessons learned during feature
+development by the first author. We hope our study provides a holistic
+view on scientific library development and surfaces opportunities for future
+studies into effective strategies for RSEs.
+
+---
+
+### How to Grow Diverse and Sustainable Teams through Mentorship
+
+*Caleb Jackson*
+
+Abstract	The chief question I will address is: in a sea of open-source
+projects, how might mid- or senior-level developers best mentor early career
+developers? As a software engineering apprentice, I have had the unique
+experience of swimming through open-source projects and ultimately finding
+tech spaces that align with my values (open science and collaboration) and
+interests (biochemistry and neuroscience). During this transition time,
+mentorship played a crucial role in making this happen!
+
+So often, tech spaces lack diversity, and when they are open to individuals
+from different backgrounds, these spaces do not feel safe. This makes the need
+for identity-related support evident. My talk highlights the importance of
+effective and empathetic mentorship and best mentorship practices for mentoring
+those with different identities from the mentee's perspective. As a Black
+trans person, I was initially hesitant to be mentored by a white person because
+sharing one's interests and admitting to not knowing where to begin felt
+vulnerable. During my talk, I plan to briefly share my story detailing how my
+mentor and I cultivated trust. This talk also provides solutions for growing
+diverse and sustainable teams where trust, learning, and experimentation are
+encouraged! I'll pinpoint the strategies my mentor and I utilized over those
+six months and have continued to use to this day.
+
+This talk is necessary for anyone interested in gaining more effective
+mentorship strategies as they guide individuals with different identities and
+for any mentees, like me, interested in advice on navigating mentor/mentee
+relationships. You don't necessarily need to hold the title of "mentor" to
+utilize these strategies; most folks in this field guide others in some
+capacity. All in all, I aim to show how mentorship plays a crucial role in
+growing diverse and sustainable teams within the workplace. 
+
+---
+
+### Best practices and Learned Lessons in Refactoring Researcher-Developed Statistical R Packages
+
+*Naeem Khoshnevis and Mahmood Mohammadi Shad*
+
+We present two years of faced challenges and success stories of collaboration
+with biostatisticians. Research software engineering is a relatively new
+career field, and the structure, responsibilities, evaluation metrics, and
+collaboration boundaries are not firmly defined. All of these can build
+unreasonable expectations and can negatively affect both researchers and RSEs.
+The best practices and faced challenges discussed here can be an excellent
+heuristic for the current RSEs to improve productivity and give a better
+picture for the potential RSEs on what to expect. We discuss the followed
+software engineering best practices and learned lessons, including unit
+testing, functional testing, Continues Integration, documentation for users
+and developers, containerizing development environment, and practical use of
+version control systems. We also discuss requirements for addressing different
+types of projects based on the maturity of the research (completed, in
+progress, not started). Efficient communication is an essential part of the
+collaboration, which can include a broad spectrum of researchers (from
+undergraduate students to a well-established PI). We discuss the best practices
+for communication and how provide tips on how to prepare good documentation
+and test cases.
+
+Our two years' experience shows how taking care of small, yet important
+details can help researchers and RSEs in building sustainable and better
+scientific software. 

--- a/pages/agenda.md
+++ b/pages/agenda.md
@@ -1,44 +1,94 @@
 ---
 layout: page
-title: Agenda
+title: Workshop Agenda
+subtitle: Agenda
+description: Agenda
 permalink: /agenda/
 ---
 
-<div class="main-explain-area jumbotron">
+The full list of abstracts for all accepted talks can be found [here]({{ site.baseurl }}/abstracts).
 
-    <h3>Link to workshop on <a href="https://www.escience-conference.org/2022/workshops">eScience 2022 website</a>
-    </h3>
-    
-    <em>All times are Mountain Standard Time (UTC-7).</em>
-    <br>
-    <br>
-    <h4>Date TBD</h4>
-    
-    <ul>
-      <li><strong>TBD</strong> – Session 1 (60 min)</li>
-      <ul>
-         <li>15 min: Introduction and overview of day</li>
-         <li>30 min: Keynote: TBD</li>
-         <li>15 min: Q & A</li>
-      </ul>
-      <li><strong>TBD</strong> – Break</li>
-      <li><strong>TBD</strong> – Session 2 (150 min)</li>
-      <ul>
-         <li>40 min: Short talks</li>
-         <li>30 min: Panel Discussion / Q & A</li>
-         <li>5 min: Short break / organize breakout groups</li>
-         <li>60 min: Breakout group discussions</li>
-         <li>15 min: Report-backs from breakout groups</li>
-      </ul>
-      <li><strong>TBD</strong> – Break / Meal</li>
-      <li><strong>TBD</strong> – Session 4 (150 min)</li>
-      <ul>
-         <li>40 min: Short talks</li>
-         <li>30 min: Panel Discussion / Q & A</li>
-         <li>5 min: Short break / organize breakout groups</li>
-         <li>60 min: Breakout group discussions</li>
-         <li>15 min: Report-backs from breakout groups</li>
-      </ul>
-      <li><strong>TBD</strong> – Closeout (15 min)</li>
-    </ul>
-</div>
+[Workshop on eScience 2022 website](https://www.escience-conference.org/2022/workshops)
+
+## Tuesday, October 11, 2022, 1:30 - 4:30 PM MT
+
+Moderator: Miranda Mundt
+
+<table>
+<tr>
+  <th style="min-width: 150px;">Time (MT)</th>
+  <th>Session Title </th>
+</tr>
+<tr>
+  <td>1:30 PM</td>
+  <td>Intro (Welcome, What is the US-RSE?)</td>
+</tr>
+<tr>
+  <td style="vertical-align: top;"> 1:35 PM</td>
+  <td>
+    <i>Talk</i><br>
+    <b><a href="{{ site.baseurl }}/abstracts#benefits-and-limitations-of-jupyter-based-scientific-web-applications">Benefits and Limitations of Jupyter-based Scientific Web Applications</a></b> <br>
+    <i>Nicole Brewer</i>, Rob Campbell, Rajesh Kalyanam, I Luk Kim, and Carol X. Song
+  </td>
+</tr>
+<tr>
+  <td style="vertical-align: top;">1:47 PM</td>
+  <td>
+    <i>Talk</i> <br>
+    <b><a href="{{ site.baseurl }}/abstracts#roles-of-professional-research-software-engineers-in-the-science-gateway-landscape">Roles of Professional Research Software Engineers in the Science Gateway Landscape</a></b> <br>
+    <i>Sandra Gesing</i>
+  </td>
+</tr>
+<tr>
+  <td style="vertical-align: top;">1:59 PM</td>
+  <td>
+    <i>Talk</i> <br>
+    <b><a href="{{ site.baseurl }}/abstracts#half-precision-scalar-support-in-kokkos-and-kokkos-kernels-an-engineering-study-and-experience-report">Half-Precision Scalar Support in Kokkos and Kokkos Kernels: An Engineering Study and Experience Report</a></b> <br>
+    <i>Evan Harvey</i>, Reed Milewicz, Christian Trott, Luc Berger-Vergiat, and Siva Rajamanickam
+  </td>
+</tr>
+<tr>
+  <td style="vertical-align: top;">2:11 PM</td>
+  <td>
+    <i>Talk</i> <br>
+    <b><a href="{{ site.baseurl }}/abstracts#how-to-grow-diverse-and-sustainable-teams-through-mentorship">How to Grow Diverse and Sustainable Teams through Mentorship</a></b> <br>
+    <i>Caleb Jackson</i>
+  </td>
+</tr>
+<tr>
+  <td style="vertical-align: top;">2:23 PM</td>
+  <td>
+    <i>Talk</i> <br>
+    <b><a href="{{ site.baseurl }}/abstracts#best-practices-and-learned-lessons-in-refactoring-researcher-developed-statistical-r-packages">Best practices and Learned Lessons in Refactoring Researcher-Developed Statistical R Packages</a></b> <br>
+    <i>Naeem Khoshnevis</i> and Mahmood Mohammadi Shad
+  </td>
+</tr>
+<tr>
+  <td>2:35 PM</td>
+  <td><i>5 min break</i></td>
+</tr>
+<tr>
+  <td style="vertical-align: top;">2:40 PM</td>
+  <td><b>Panel Discussion / Q&A</b></td>
+</tr>
+<tr>
+  <td>3:00 PM</td>
+  <td><i>30 min break</i></td>
+</tr>
+<tr>
+  <td>3:30 PM</td>
+  <td><b>Organize breakout discussion</b></td>
+</tr>
+<tr>
+  <td>3:35 PM</td>
+  <td><b>Breakout Discussions</b></td>
+</tr>
+<tr>
+  <td>4:15 PM</td>
+  <td><b>Report back</b></td>
+</tr>
+<tr>
+  <td>4:27 PM</td>
+  <td>Workshop Closeout</td>
+</tr>
+</table>

--- a/pages/agenda.md
+++ b/pages/agenda.md
@@ -77,7 +77,7 @@ Moderator: Miranda Mundt
 </tr>
 <tr>
   <td>3:30 PM</td>
-  <td><b>Organize breakout discussion</b></td>
+  <td><i>Organize breakout discussions</i></td>
 </tr>
 <tr>
   <td>3:35 PM</td>

--- a/pages/call.md
+++ b/pages/call.md
@@ -37,10 +37,10 @@ Submission website:
 - Submissions open:  Monday, April 11, 2022
 - ~~Full paper submissions due (to be included with official proceedings):  Tuesday, May 31, 2022~~
 - ~~Notifications sent:  Monday, June 27, 2022~~
-- Abstract/short paper submissions due (will NOT be included with official proceedings): Monday, July 18, 2022 - **EXTENDED**
-- Notifications sent:  Monday, August 1, 2022
-- Program finalized:  Monday, August 15, 2022
-- Workshop date:  TBD
+- ~~Abstract/short paper submissions due (will NOT be included with official proceedings): Monday, July 18, 2022 - **EXTENDED**~~
+- ~~Notifications sent:  Monday, August 1, 2022~~
+- Program finalized:  Wednesday, August 17, 2022
+- Workshop date:  Tuesday, October 11, 1:30-4:30PM (MDT)
 
 ### Questions?
 


### PR DESCRIPTION
This PR adds the full finalized agenda with abstracts (**NOTE**: speakers are in alphabetical order by presenter's last name).

This also adds some corrections on dates, adds the workshop date, and strikes-out past deadlines.